### PR TITLE
cancel instead of burn, redeem multiple, supply

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@
 This is a smart contract and dApp that manages token grants with vesting schedules.
 
 Each grant is represented as an NFT. It has the following properties:
-* `tokenAddress` - The address of the tokens being provided by the grant.
-* `startTimestamp` - The timestamp (in seconds) when the grant begins to vest. 
-* `cliffTimestamp` - The timestamp (in seconds) before which no tokens can be redeemed.
-* `vestInterval` - The duration (in seconds) for each additional amount to vest.
-* `vestAmount` - The amount of tokens that will vest each interval.
-* `totalAmount` - The total amount of tokens that will vest for this grant.
-* `amountRedeemed` - The amount of tokens already redeemed under this grant.
+
+- `tokenAddress` - The address of the tokens being provided by the grant.
+- `startTimestamp` - The timestamp (in seconds) when the grant begins to vest.
+- `cliffTimestamp` - The timestamp (in seconds) before which no tokens can be redeemed.
+- `vestInterval` - The duration (in seconds) for each additional amount to vest.
+- `vestAmount` - The amount of tokens that will vest each interval.
+- `totalAmount` - The total amount of tokens that will vest for this grant.
+- `amountRedeemed` - The amount of tokens already redeemed under this grant.
 
 The contract owner is able to manage grants using the `mint()`, `burn()`, and `updateGrant()` functions. The owner can also withdraw tokens using the `withdraw()` function. The dApp assumes this will be a multisig wallet on Gnosis Safe. Ownership can be transferred using the `nominateOwner()` and `acceptOwnership()` functions.
 
@@ -19,9 +20,9 @@ Holders of the NFT are able to redeem available tokens using the `redeem()` or `
 
 ## Development Environment
 
-* Run `npx hardhat node`
-* In a separate tab, `npx hardhat run --network localhost scripts/local-deploy.js`
-* Then start the front end, `cd frontend && npm run dev` (ensure to `npm i` here as well). Owner is HH wallet 0, grantee is HH wallet 1.
+- Run `npx hardhat node`
+- In a separate tab, `npx hardhat run --network localhost scripts/local-deploy.js`
+- Then start the front end, `cd frontend && npm run dev` (ensure to `npm i` here as well). Owner is HH wallet 0, grantee is HH wallet 1.
 
 ## Technical Specification
 
@@ -29,20 +30,20 @@ This an ERC-721 contract that implements the enumerable extension. Each NFT corr
 
 ### Owner
 
-* The contract has a single owner, initialized in the constructor.
-* Ownership can be transferred by nominating a new owner using the `nominateOwner()` function. The nominated owner can then claim ownership by calling `acceptOwnership()`. Only the current owner should be able to nominate a new owner. Only the nominated owner (`nominatedOwner`) should be able to accept ownership.
-* The owner is expected to supply tokens being granted with this contract (`tokenAddress`) to the contract using `supply()`, though anyone could transfer any tokens to this contract.
-* The owner, and only the owner, should be able to withdraw all of any token from the contract using the `withdraw()` method.
-* The owner, and only the owner, can issue a new grant using the `mint()` function, specifying the grantee's address and all of the properties in the `Grant` struct. `tokenCounter` increments such that each grant always has a unique ID.
-* The owner, and only the owner, can update a grant based on it's token ID. They should be able to update all properties in the `Grant` struct.
-* The owner, and only the owner, should be able to destroy a grant with the `burn()` function. No one, including the grantee assigned to that grant, should be able to redeem tokens based on a grant that has been burned.
+- The contract has a single owner, initialized in the constructor.
+- Ownership can be transferred by nominating a new owner using the `nominateOwner()` function. The nominated owner can then claim ownership by calling `acceptOwnership()`. Only the current owner should be able to nominate a new owner. Only the nominated owner (`nominatedOwner`) should be able to accept ownership.
+- The owner is expected to supply tokens being granted with this contract (`tokenAddress`) to the contract using `supply()`, though anyone could transfer any tokens to this contract.
+- The owner, and only the owner, should be able to withdraw all of any token from the contract using the `withdraw()` method.
+- The owner, and only the owner, can issue a new grant using the `mint()` function, specifying the grantee's address and all of the properties in the `Grant` struct. `tokenCounter` increments such that each grant always has a unique ID.
+- The owner, and only the owner, can update a grant based on it's token ID. They should be able to update all properties in the `Grant` struct.
+- The owner, and only the owner, should be able to cancel a grant with the `cancelGrant()` function. No one, including the grantee assigned to that grant, should be able to redeem tokens based on a grant that has been cancelled.
 
 ### Grantee
 
-* The grantee (and only the grantee) should be able to redeem tokens from the contract according to the vesting schedule associated with the NFTs they hold.
-    - Starting at the `startTimestamp`, each `vestInterval` should vest `vestAmount` of tokens.
-    - No tokens should vest prior to the `cliffTimestamp`, but this should not be taken into account when calculating the amount vested after the cliff has passed. For example, given a `vestAmount` of 100, a `vestInterval` of 3 months, and a `cliffTimestamp` of +6 months, 0 tokens should be vested at +5 months, 200 tokens should be vested at +6 months, and 300 tokens should be vested at +9 months.
-    - Under no circumstances should a grant provide access to more than the `totalAmount` of tokens.
-    - Users are able to redeem the amount of vested tokens minus the amount of tokens they've already redeemed.
-* The grantee (and only the grantee) should be able to redeem tokens (as specified above) and also transfer any amount of any ERC-20 token to this contract in a single transaction using the `redeemWithTransfer()` function.
-* The grantee should be able to transfer that grant to another address using the standard functions in the ERC-721 specification.
+- The grantee (and only the grantee) should be able to redeem tokens from the contract according to the vesting schedule associated with the NFTs they hold.
+  - Starting at the `startTimestamp`, each `vestInterval` should vest `vestAmount` of tokens.
+  - No tokens should vest prior to the `cliffTimestamp`, but this should not be taken into account when calculating the amount vested after the cliff has passed. For example, given a `vestAmount` of 100, a `vestInterval` of 3 months, and a `cliffTimestamp` of +6 months, 0 tokens should be vested at +5 months, 200 tokens should be vested at +6 months, and 300 tokens should be vested at +9 months.
+  - Under no circumstances should a grant provide access to more than the `totalAmount` of tokens.
+  - Users are able to redeem the amount of vested tokens minus the amount of tokens they've already redeemed.
+- The grantee (and only the grantee) should be able to redeem tokens (as specified above) and also transfer any amount of any ERC-20 token to this contract in a single transaction using the `redeemWithTransfer()` function.
+- The grantee should be able to transfer that grant to another address using the standard functions in the ERC-721 specification.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Each grant is represented as an NFT. It has the following properties:
 - `vestAmount` - The amount of tokens that will vest each interval.
 - `totalAmount` - The total amount of tokens that will vest for this grant.
 - `amountRedeemed` - The amount of tokens already redeemed under this grant.
+- `cancelled` - Whether this grant was cancelled by the contract, this is the only mutable property.
 
 The contract owner is able to manage grants using the `mint()`, `cancelGrant()`, and `replaceGrant()` functions. The owner can also withdraw tokens using the `withdraw()` function. The dApp assumes this will be a multisig wallet on Gnosis Safe. Ownership can be transferred using the `nominateOwner()` and `acceptOwnership()` functions.
 
-Holders of the NFT are able to redeem available tokens using the `redeem()` or `redeemWithTransfer()` methods.
+Holders of the NFT are able to redeem available tokens using the `redeem()`, `redeemMultiple()`, `redeemAll()`, or `redeemWithTransfer()` methods.
 
 ## Development Environment
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Holders of the NFT are able to redeem available tokens using the `redeem()` or `
 ## Development Environment
 
 * Run `npx hardhat node`
-* In a seperate tab, `npx hardhat run --network localhost scripts/local-deploy.js`
-* Then start the front end, `cd frontend && npm run dev`
+* In a separate tab, `npx hardhat run --network localhost scripts/local-deploy.js`
+* Then start the front end, `cd frontend && npm run dev` (ensure to `npm i` here as well). Owner is HH wallet 0, grantee is HH wallet 1.
 
 ## Technical Specification
 
@@ -31,7 +31,7 @@ This an ERC-721 contract that implements the enumerable extension. Each NFT corr
 
 * The contract has a single owner, initialized in the constructor.
 * Ownership can be transferred by nominating a new owner using the `nominateOwner()` function. The nominated owner can then claim ownership by calling `acceptOwnership()`. Only the current owner should be able to nominate a new owner. Only the nominated owner (`nominatedOwner`) should be able to accept ownership.
-* The owner is expected to transfer the tokens being granted with this contract (`tokenAddress`) to the contract, though anyone could transfer any tokens to this contract.
+* The owner is expected to supply tokens being granted with this contract (`tokenAddress`) to the contract using `supply()`, though anyone could transfer any tokens to this contract.
 * The owner, and only the owner, should be able to withdraw all of any token from the contract using the `withdraw()` method.
 * The owner, and only the owner, can issue a new grant using the `mint()` function, specifying the grantee's address and all of the properties in the `Grant` struct. `tokenCounter` increments such that each grant always has a unique ID.
 * The owner, and only the owner, can update a grant based on it's token ID. They should be able to update all properties in the `Grant` struct.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Each grant is represented as an NFT. It has the following properties:
 - `totalAmount` - The total amount of tokens that will vest for this grant.
 - `amountRedeemed` - The amount of tokens already redeemed under this grant.
 
-The contract owner is able to manage grants using the `mint()`, `burn()`, and `updateGrant()` functions. The owner can also withdraw tokens using the `withdraw()` function. The dApp assumes this will be a multisig wallet on Gnosis Safe. Ownership can be transferred using the `nominateOwner()` and `acceptOwnership()` functions.
+The contract owner is able to manage grants using the `mint()`, `cancelGrant()`, and `replaceGrant()` functions. The owner can also withdraw tokens using the `withdraw()` function. The dApp assumes this will be a multisig wallet on Gnosis Safe. Ownership can be transferred using the `nominateOwner()` and `acceptOwnership()` functions.
 
 Holders of the NFT are able to redeem available tokens using the `redeem()` or `redeemWithTransfer()` methods.
 
@@ -35,7 +35,7 @@ This an ERC-721 contract that implements the enumerable extension. Each NFT corr
 - The owner is expected to supply tokens being granted with this contract (`tokenAddress`) to the contract using `supply()`, though anyone could transfer any tokens to this contract.
 - The owner, and only the owner, should be able to withdraw all of any token from the contract using the `withdraw()` method.
 - The owner, and only the owner, can issue a new grant using the `mint()` function, specifying the grantee's address and all of the properties in the `Grant` struct. `tokenCounter` increments such that each grant always has a unique ID.
-- The owner, and only the owner, can update a grant based on it's token ID. They should be able to update all properties in the `Grant` struct.
+- The owner, and only the owner, can replace a grant based on it's token ID. This should mint a replacement grant with new attributes to the previous grantee.
 - The owner, and only the owner, should be able to cancel a grant with the `cancelGrant()` function. No one, including the grantee assigned to that grant, should be able to redeem tokens based on a grant that has been cancelled.
 
 ### Grantee

--- a/contracts/Vester.sol
+++ b/contracts/Vester.sol
@@ -86,12 +86,20 @@ contract Vester is ERC721Enumerable {
         return amount;
     }
 
+    /// @notice Supply tokens to this contract so that tokens don't need to be sent directly to contract
+    /// @param tokenAddress The address of the ERC20 token to supply
+    /// @param amount amount to supply
+    function supply(address tokenAddress, uint amount) external {
+        IERC20(tokenAddress).safeTransferFrom(msg.sender, address(this), amount);
+
+        emit Supply(msg.sender, tokenAddress, amount);
+    }
+
     /// @notice Withdraw tokens owned by this contract to the caller
     /// @dev Only the owner of the contract may call this function.
     /// @param withdrawalTokenAddress The address of the ERC20 token to redeem
     function withdraw(address withdrawalTokenAddress, uint withdrawalTokenAmount) public onlyOwner {
-        IERC20 tokenContract = IERC20(withdrawalTokenAddress);
-        tokenContract.safeTransfer(msg.sender, withdrawalTokenAmount);
+        IERC20(withdrawalTokenAddress).safeTransfer(msg.sender, withdrawalTokenAmount);
 
         emit Withdrawal(msg.sender, withdrawalTokenAddress, withdrawalTokenAmount);
     }
@@ -169,6 +177,7 @@ contract Vester is ERC721Enumerable {
     event GrantUpdated(uint indexed tokenId, address indexed tokenAddress, uint64 startTimestamp, uint64 cliffTimestamp, uint128 vestAmount, uint128 totalAmount, uint128 amountRedeemed, uint32 vestInterval);
     event GrantCreated(uint indexed tokenId);
     event GrantDeleted(uint indexed tokenId);
+    event Supply(address supplierAddress, address indexed tokenAddress, uint amount);
     event Withdrawal(address indexed withdrawerAddress, address indexed withdrawalTokenAddress, uint amount);
     event OwnerNomination(address indexed newOwner);
     event OwnerUpdate(address indexed oldOwner, address indexed newOwner);

--- a/contracts/Vester.sol
+++ b/contracts/Vester.sol
@@ -63,7 +63,7 @@ contract Vester is ERC721Enumerable, ReentrancyGuard {
 
         if (amount == 0) {
             if (requireNonZero) {
-                revert("No tokens available for redemption");        
+                revert("No tokens available for redemption of grant");        
             } else {
                 return; // nothing to do
             }
@@ -104,7 +104,7 @@ contract Vester is ERC721Enumerable, ReentrancyGuard {
         }        
     }
 
-    /// @notice Calculate the amount that has vested for a given address
+    /// @notice Calculate the amount that has vested for a given grant
     /// @param tokenId The ID of the grant
     /// @return The amount of vested tokens, denominated in tokens * 10^18
     function amountVested(uint tokenId) public view returns (uint128) {

--- a/test/vester.js
+++ b/test/vester.js
@@ -40,7 +40,7 @@ describe("Vester", function () {
     const [owner, user] = await ethers.getSigners();
 
     await expect(this.vester.connect(user).withdraw(ZERO_ADDRESS, 1)).to.be.revertedWith('Only the owner can call this function.');
-    await expect(this.vester.connect(user).updateGrant(1, this.tokenContract.address, 1, 1, 1, 1, 1, 1)).to.be.revertedWith('Only the owner can call this function.');
+    await expect(this.vester.connect(user).replaceGrant(1, this.tokenContract.address, 1, 1, 1, 1, 1, 1)).to.be.revertedWith('Only the owner can call this function.');
     await expect(this.vester.connect(user).mint(ZERO_ADDRESS, this.tokenContract.address, 1, 1, 1, 1, 1, 1)).to.be.revertedWith('Only the owner can call this function.');
     await expect(this.vester.connect(user).cancelGrant(1)).to.be.revertedWith('Only the owner can call this function.');
     await expect(this.vester.connect(user).nominateOwner(ZERO_ADDRESS)).to.be.revertedWith('Only the owner can call this function.');
@@ -63,7 +63,7 @@ describe("Vester", function () {
     expect(grantData.vestInterval).to.equal(7889400)
   });
 
-  it("Should allow a grant to be updated", async function () {
+  it("Should allow a grant to be replaced", async function () {
     const [owner, grantee] = await ethers.getSigners();
     const currentTimestamp = (await ethers.provider.getBlock("latest")).timestamp
 
@@ -73,7 +73,7 @@ describe("Vester", function () {
     expect(grantData.totalAmount).to.equal(ethers.utils.parseEther("30000"))
     expect(grantData.amountRedeemed).to.equal(0)
 
-    await this.vester.connect(owner).updateGrant(
+    await this.vester.connect(owner).replaceGrant(
       0,
       this.tokenContract.address,
       grantData.startTimestamp,
@@ -84,10 +84,14 @@ describe("Vester", function () {
       grantData.vestInterval,
     );
 
-    grantData = await this.vester.grants(0)
+    grantData = await this.vester.grants(1);
     expect(grantData.vestAmount).to.equal(ethers.utils.parseEther("3000"))
     expect(grantData.totalAmount).to.equal(ethers.utils.parseEther("40000"))
     expect(grantData.amountRedeemed).to.equal(0)
+
+    const prevGrant = await this.vester.grants(0);
+    expect(prevGrant.cancelled).to.equal(true);
+    expect(prevGrant.vestAmount).to.equal(ethers.utils.parseEther("2500")); // data unchanged
   })
 
   it("Should allow a grant to be cancelled", async function () {

--- a/test/vester.js
+++ b/test/vester.js
@@ -156,6 +156,31 @@ describe("Vester", function () {
     expect(await this.tokenContract.balanceOf(grantee.address)).to.equal(ethers.utils.parseEther("30000").div(4).div(3).mul(2));
   });
 
+  it("Should allow multiple or all grants to be redeemed", async function () {
+    const [, grantee, someoneElse] = await ethers.getSigners();
+    const currentTimestamp = (await ethers.provider.getBlock("latest")).timestamp
+
+    await this.tokenContract.mint(this.vester.address, ethers.utils.parseEther("30000"))
+    // mint five tokens, one for someone else
+    await this.vester.mint(grantee.address, this.tokenContract.address, currentTimestamp, currentTimestamp, ethers.utils.parseEther("2500"), ethers.utils.parseEther("30000"), 0, 7889400)
+    await this.vester.mint(grantee.address, this.tokenContract.address, currentTimestamp, currentTimestamp, ethers.utils.parseEther("2500"), ethers.utils.parseEther("30000"), 0, 7889400)
+    await this.vester.mint(grantee.address, this.tokenContract.address, currentTimestamp, currentTimestamp, ethers.utils.parseEther("2500"), ethers.utils.parseEther("30000"), 0, 7889400)
+    await this.vester.mint(grantee.address, this.tokenContract.address, currentTimestamp, currentTimestamp, ethers.utils.parseEther("2500"), ethers.utils.parseEther("30000"), 0, 7889400)
+    await this.vester.mint(someoneElse.address, this.tokenContract.address, currentTimestamp, currentTimestamp, ethers.utils.parseEther("2500"), ethers.utils.parseEther("30000"), 0, 7889400)
+    await network.provider.send("evm_increaseTime", [7889400])
+    await network.provider.send("evm_mine")
+
+    // redeem specific two
+    await this.vester.connect(grantee).redeemMultiple([0, 1]);
+    // two redeemed
+    expect(await this.tokenContract.balanceOf(grantee.address)).to.equal(ethers.utils.parseEther("2500").mul(2));
+
+    // two more are redeemed by redeemAll
+    await this.vester.connect(grantee).redeemAll();
+    // two more were redeemed
+    expect(await this.tokenContract.balanceOf(grantee.address)).to.equal(ethers.utils.parseEther("2500").mul(4));
+  });
+
   it("Should allow tokens to be redeemed with a token deposit", async function () {
     const [owner, grantee] = await ethers.getSigners();
     const currentTimestamp = (await ethers.provider.getBlock("latest")).timestamp

--- a/test/vester.js
+++ b/test/vester.js
@@ -104,7 +104,7 @@ describe("Vester", function () {
   })
 
   // Grant Transfer
-  it("Should allow a grant to be transfered", async function () {
+  it("Should allow a grant to be transferred", async function () {
     const [owner, grantee, futureGrantee] = await ethers.getSigners();
     const currentTimestamp = (await ethers.provider.getBlock("latest")).timestamp
 
@@ -155,6 +155,26 @@ describe("Vester", function () {
 
     expect(await this.tokenContract.balanceOf(grantee.address)).to.equal(ethers.utils.parseEther("30000").div(4).div(3).mul(2));
     expect(await incomingTokenContract.balanceOf(this.vester.address)).to.equal(ethers.utils.parseEther("1000"));
+  });
+
+  // Supply
+  it("Should allow tokens to be supplied by anyone", async function () {
+    const [, , someoneElse] = await ethers.getSigners();
+
+    await this.tokenContract.mint(someoneElse.address, ethers.utils.parseEther("1000"))
+
+    const amount = ethers.utils.parseEther("500");
+    // approve tokens to vester
+    await this.tokenContract.connect(someoneElse).approve(this.vester.address, amount);
+
+    // supply
+    await this.vester.connect(someoneElse).supply(this.tokenContract.address, amount);
+
+    // contract should have tokens now
+    expect(await this.tokenContract.balanceOf(this.vester.address)).to.equal(amount);
+
+    // no allowance
+    await expect(this.vester.connect(someoneElse).supply(this.tokenContract.address, amount)).to.revertedWith("allowance");
   });
 
   // Withdrawal

--- a/test/vester.js
+++ b/test/vester.js
@@ -61,6 +61,17 @@ describe("Vester", function () {
     expect(grantData.startTimestamp.toNumber()).to.be.closeTo(Date.now() / 1000, 100)
     expect(grantData.cliffTimestamp.toNumber()).to.be.closeTo((Date.now() / 1000) + (grantData.vestInterval * 2), 100)
     expect(grantData.vestInterval).to.equal(7889400)
+
+    // basic validation
+    await expect(
+      this.vester.mint(grantee.address, this.tokenContract.address, 0, currentTimestamp + (7889400 * 2), ethers.utils.parseEther("2500"), ethers.utils.parseEther("30000"), 0, 7889400)
+    ).to.revertedWith("startTimestamp");
+    await expect(
+      this.vester.mint(grantee.address, this.tokenContract.address, currentTimestamp, currentTimestamp + (7889400 * 2), ethers.utils.parseEther("2500"), ethers.utils.parseEther("30000"), 0, 0)
+    ).to.revertedWith("vestInterval");
+    await expect(
+      this.vester.mint(grantee.address, this.tokenContract.address, currentTimestamp, currentTimestamp + (7889400 * 2), ethers.utils.parseEther("2500"), ethers.utils.parseEther("30000"), ethers.utils.parseEther("30001"), 7889400)
+    ).to.revertedWith("redeemed");
   });
 
   it("Should allow a grant to be replaced", async function () {


### PR DESCRIPTION
Changes:
- Grants can be cancelled, but not burned. Grants attributes are not mutable by owner, except for `cancelled` property. Replace grants instead of update grant method.
- Redeeming multiple grants in same transaction. Reentrancy guard added due to interactions and effects happening in a loop.
- Supply method to avoid transferring tokens to contract addresses.
- Some input validation on mint.
- Update documentation, **did not update the UI to include new redeem methods**.

Testing: ran tests

## :warning: UI was not updated for the new ABI, renamed and added methods, or renamed / removed events.